### PR TITLE
Devcon adapted to be included in Devon dist (issue #101)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,9 @@
      <artifactId>javafx</artifactId>
      <version>2.2</version>
      <!-- For Java 7 -->
-      <systemPath>${java.home}/lib/jfxrt.jar</systemPath>
-     <!-- <systemPath>${java.home}/lib/ext/jfxrt.jar</systemPath>-->
+     <!-- <systemPath>${java.home}/lib/jfxrt.jar</systemPath> -->
+     <!-- For Java 8 -->
+     <systemPath>${java.home}/lib/ext/jfxrt.jar</systemPath>
      <scope>system</scope>
   </dependency>
 

--- a/src/main/java/com/devonfw/devcon/Devcon.java
+++ b/src/main/java/com/devonfw/devcon/Devcon.java
@@ -12,7 +12,8 @@ import com.devonfw.devcon.common.api.CommandRegistry;
 import com.devonfw.devcon.common.impl.CommandManagerImpl;
 import com.devonfw.devcon.common.impl.CommandRegistryImpl;
 import com.devonfw.devcon.common.impl.JavaScriptsCmdRegistryImpl;
-import com.devonfw.devcon.common.utils.ContextPathInfo;
+import com.devonfw.devcon.common.utils.Constants;
+import com.devonfw.devcon.common.utils.Utils;
 import com.devonfw.devcon.input.ConsoleInput;
 import com.devonfw.devcon.input.ConsoleInputManager;
 import com.devonfw.devcon.input.Input;
@@ -28,32 +29,51 @@ import com.google.common.base.Optional;
  */
 public class Devcon {
 
+  /**
+   * current version of the tool
+   */
   public static final String VERSION = "1.2.0";
 
-  // Mock url. Can be used with node.js http-server, for example. See public/version.json for data
-  // public static final String VERSION_URL = "http://localhost:8080/version.json";
+  /**
+   * url where the versions configuration file is located
+   */
   public static final String VERSION_URL = "http://devonfw.github.io/download/devcon/version.json";
 
+  /**
+   *
+   */
   public static final Version VERSION_ = Version.valueOf(VERSION);
 
+  /**
+   * message to be shown as version of the tool
+   */
   public static final String DEVCON_VERSION = "devcon v." + VERSION;
 
   /**
    * to be used as version of devon.json files
    */
-  public static final String DEVON_DEFAULT_VERSION = "2.0.1";
+  public static final String DEVON_DEFAULT_VERSION = "2.1.0";
 
+  /**
+   * devcon's starter message
+   */
   public static final String DEVCON_BANNER = "Hello, this is Devcon!\n" + "Copyright (c) 2016 Capgemini";
 
-  // Determine whether app is inside an "executable jar" or not (made with Eclipse: has an "resource" folder"
+  /**
+   * Determine whether app is inside an "executable jar" or not (made with Eclipse: has an "resource" folder"
+   */
   public static final boolean IN_EXEC_JAR =
       ClassLoader.getSystemClassLoader().getResource("resources/execjar.txt") != null;
 
-  // Obtain script engine; only on Java 1.8+ is Javascript supported (version "Nashorn")
+  /**
+   * Obtain script engine; only on Java 1.8+ is Javascript supported (version "Nashorn")
+   */
   public static final Optional<ScriptEngine> scriptEngine =
-      Optional.fromNullable(new ScriptEngineManager().getEngineByName("nashorn"));
+      Optional.fromNullable(new ScriptEngineManager().getEngineByName(Constants.SCRIPT_ENGINE_NAME));
 
-  // Show stack-trace when errors are thrown by the command
+  /**
+   * Show stack-trace when errors are thrown by the command
+   */
   public static boolean SHOW_STACK_TRACE = false;
 
   /**
@@ -65,16 +85,16 @@ public class Devcon {
 
     Input input = new ConsoleInput(System.in, System.out);
     Output output = new ConsoleOutput(System.out);
-    CommandRegistry registry = new CommandRegistryImpl("com.devonfw.devcon.modules.*");
+    CommandRegistry registry = new CommandRegistryImpl(Constants.MODULES_LOCATION);
 
-    Path scriptDir = ContextPathInfo.INSTANCE.getHomeDirectory().resolve(".devcon/scripts");
+    Path scriptDir = Utils.getScriptDir();
+
     if (scriptEngine.isPresent() && scriptDir.toFile().exists()) {
       try {
         JavaScriptsCmdRegistryImpl jsregistry = new JavaScriptsCmdRegistryImpl(scriptDir);
         registry.add(jsregistry);
 
       } catch (ParseException | IOException e) {
-        // TODO Auto-generated catch block
         e.printStackTrace();
         System.exit(-1);
       }

--- a/src/main/java/com/devonfw/devcon/common/utils/Constants.java
+++ b/src/main/java/com/devonfw/devcon/common/utils/Constants.java
@@ -12,6 +12,11 @@ public final class Constants {
   public static final String MODULES_PACKAGE = "com.devonfw.devcon.modules";
 
   /**
+   * the location for the Devcon modules
+   */
+  public static final String MODULES_LOCATION = "com.devonfw.devcon.modules.*";
+
+  /**
    * the path to the folder where the resources are located
    */
   public static final String RESOURCES_PATH = "src/main/resources/";
@@ -248,4 +253,9 @@ public final class Constants {
    * Taskkill commands in windows
    */
   public static final String TASKKILL_PID_CMD = "taskkill /F /PID ";
+
+  /**
+   * Script (JS) engine name
+   */
+  public static final String SCRIPT_ENGINE_NAME = "nashorn";
 }

--- a/src/main/java/com/devonfw/devcon/common/utils/Utils.java
+++ b/src/main/java/com/devonfw/devcon/common/utils/Utils.java
@@ -32,8 +32,10 @@ import org.apache.commons.lang3.tuple.Pair;
 import com.devonfw.devcon.Devcon;
 import com.devonfw.devcon.common.api.Command;
 import com.devonfw.devcon.common.api.CommandModuleInfo;
+import com.devonfw.devcon.common.api.data.DistributionInfo;
 import com.devonfw.devcon.common.api.data.ProjectType;
 import com.devonfw.devcon.output.Output;
+import com.google.common.base.Optional;
 
 /**
  * General utilities
@@ -46,12 +48,15 @@ public class Utils {
 
   private static final String OPTIONAL = "optionalParameters";
 
+  private static final String DIST_SCRIPTS = "software/devcon/scripts";
+
+  private static final String LOCAL_SCRIPTS = ".devcon/scripts";
+
   public static File getApplicationPath() {
 
     try {
       return new File(Devcon.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath());
     } catch (URISyntaxException e) {
-      // TODO Auto-generated catch block
       e.printStackTrace();
       return null;
     }
@@ -178,31 +183,6 @@ public class Utils {
   }
 
   /**
-   * @param repoUrl
-   * @param cloneDir
-   * @param gitDir
-   * @throws Exception
-   */
-  /*
-   * public static void cloneRepository(String repoUrl, String cloneDir, String gitDir) throws Exception {
-   *
-   * try {
-   *
-   * if (gitDir == null || gitDir.isEmpty()) { gitDir = Utils.getGITBinPath(); } ProcessBuilder processBuilder = new
-   * ProcessBuilder(gitDir + Constants.GIT_EXE, Constants.CLONE_OPTION, repoUrl, cloneDir); processBuilder.directory(new
-   * File(gitDir));
-   *
-   * Process process = processBuilder.start();
-   *
-   * final InputStream isError = process.getErrorStream(); final InputStream isOutput = process.getInputStream();
-   *
-   * processErrorAndOutPut(isError, isOutput);
-   *
-   * // Wait to get exit value try { process.waitFor(); } catch (InterruptedException e) { throw e; } } catch (Exception
-   * e) { throw e; } }
-   */
-
-  /**
    * @param isError
    * @param isOutput
    */
@@ -212,24 +192,6 @@ public class Utils {
     final InputStreamReader isErrReader = new InputStreamReader(isError);
     final InputStreamReader isOutReader = new InputStreamReader(isOutput);
 
-    // Thread to process error
-    // new Thread(new Runnable() {
-    // @Override
-    // public void run() {
-    //
-    // BufferedReader bre = new BufferedReader(isErrReader);
-    // String line;
-    // try {
-    // while ((line = bre.readLine()) != null) {
-    //
-    // output.showError(line);
-    // }
-    // } catch (Exception e) {
-    // }
-    // }
-    // }).start();
-
-    // Thread to process output
     new Thread(new Runnable() {
       @Override
       public void run() {
@@ -381,5 +343,19 @@ public class Utils {
     }
 
     return finalOrderedModuleList;
+  }
+
+  /**
+   * Returns the path where the custom JS modules should be searched
+   *
+   * @return the JS modules path
+   */
+  public static Path getScriptDir() {
+
+    Optional<DistributionInfo> distInfo = ContextPathInfo.INSTANCE.getDistributionRoot();
+
+    return distInfo.isPresent() ? distInfo.get().getPath().resolve(DIST_SCRIPTS)
+        : ContextPathInfo.INSTANCE.getHomeDirectory().resolve(LOCAL_SCRIPTS);
+
   }
 }


### PR DESCRIPTION
Now it reads the JS modules scripts from both distribution context (from dist/software/devcon/scripts) and local context ({home}/.devcon/scripts) depending on the opened command line (console.bat or local)