### PR TITLE
Updated devcon oomph setup. No eclipse target and labeled variables

### DIFF
--- a/docs/oomph/projects/Devcon.setup
+++ b/docs/oomph/projects/Devcon.setup
@@ -6,8 +6,7 @@
     xmlns:git="http://www.eclipse.org/oomph/setup/git/1.0"
     xmlns:maven="http://www.eclipse.org/oomph/setup/maven/1.0"
     xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
-    xmlns:setup.targlets="http://www.eclipse.org/oomph/setup/targlets/1.0"
-    xsi:schemaLocation="http://www.eclipse.org/oomph/setup/git/1.0 http://de-mucevolve02/oomph/tasks/models/Git.ecore http://www.eclipse.org/oomph/setup/maven/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Maven.ecore http://www.eclipse.org/oomph/setup/targlets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupTarglets.ecore"
+    xsi:schemaLocation="http://www.eclipse.org/oomph/setup/git/1.0 http://de-mucevolve02/oomph/tasks/models/Git.ecore http://www.eclipse.org/oomph/setup/maven/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Maven.ecore"
     name="devcon"
     label="devcon">
   <setupTask
@@ -16,14 +15,6 @@
       value="1024m"
       vm="true">
     <description>Set the heap space needed to work with the projects of ${scope.project.label}</description>
-  </setupTask>
-  <setupTask
-      xsi:type="setup:ResourceCreationTask"
-      excludedTriggers="STARTUP MANUAL"
-      content="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?>&#xD;&#xA;&lt;section name=&quot;Workbench&quot;>&#xD;&#xA;&#x9;&lt;section name=&quot;org.eclipse.jdt.internal.ui.packageview.PackageExplorerPart&quot;>&#xD;&#xA;&#x9;&#x9;&lt;item value=&quot;true&quot; key=&quot;group_libraries&quot;/>&#xD;&#xA;&#x9;&#x9;&lt;item value=&quot;false&quot; key=&quot;linkWithEditor&quot;/>&#xD;&#xA;&#x9;&#x9;&lt;item value=&quot;2&quot; key=&quot;layout&quot;/>&#xD;&#xA;&#x9;&#x9;&lt;item value=&quot;2&quot; key=&quot;rootMode&quot;/>&#xD;&#xA;&#x9;&#x9;&lt;item value=&quot;&amp;lt;?xml version=&amp;quot;1.0&amp;quot; encoding=&amp;quot;UTF-8&amp;quot;?&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;packageExplorer configured=&amp;quot;true&amp;quot; group_libraries=&amp;quot;1&amp;quot; layout=&amp;quot;2&amp;quot; linkWithEditor=&amp;quot;0&amp;quot; rootMode=&amp;quot;2&amp;quot; sortWorkingSets=&amp;quot;false&amp;quot; workingSetName=&amp;quot;&amp;quot;&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;localWorkingSetManager&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;workingSet editPageId=&amp;quot;org.eclipse.jdt.internal.ui.OthersWorkingSet&amp;quot; factoryID=&amp;quot;org.eclipse.ui.internal.WorkingSetFactory&amp;quot; id=&amp;quot;1382792884467_1&amp;quot; label=&amp;quot;Other Projects&amp;quot; name=&amp;quot;Other Projects&amp;quot;/&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;/localWorkingSetManager&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;activeWorkingSet workingSetName=&amp;quot;Other Projects&amp;quot;/&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;allWorkingSets workingSetName=&amp;quot;Other Projects&amp;quot;/&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;/packageExplorer&amp;gt;&quot; key=&quot;memento&quot;/>&#xD;&#xA;&#x9;&lt;/section>&#xD;&#xA;&lt;/section>&#xD;&#xA;"
-      targetURL="${workspace.location|uri}/.metadata/.plugins/org.eclipse.jdt.ui/dialog_settings.xml"
-      encoding="UTF-8">
-    <description>Initialize JDT's package explorer to show working sets as its root objects</description>
   </setupTask>
   <setupTask
       xsi:type="setup:CompoundTask"
@@ -35,7 +26,8 @@
         type="FOLDER"
         name="devcon.git.clone.location"
         value="${workspace.location/devcon}"
-        storageURI="scope://Workspace"/>
+        storageURI="scope://Workspace"
+        label=""/>
     <setupTask
         xsi:type="git:GitCloneTask"
         excludedTriggers="BOOTSTRAP"
@@ -45,65 +37,27 @@
     <setupTask
         xsi:type="setup:VariableTask"
         name="github.remote.uri"
-        storageURI="scope://Workspace">
+        storageURI="scope://Workspace"
+        label="devcon remote uri">
       <choice
-          value="ssh://git@github.com:devonfw/devcon.git"
+          value="ssh://git@github.com:${github.fork.name}/devcon.git"
           label="SSH"/>
       <choice
-          value="https://github.com/devonfw/devcon.git"
+          value="https://github.com/${github.fork.name}/devcon.git"
           label="HTTPS"/>
     </setupTask>
+    <setupTask
+        xsi:type="setup:VariableTask"
+        name="github.fork.name"
+        defaultValue="devonfw"
+        storageURI="scope://Workspace"
+        label="devcon fork"/>
   </setupTask>
   <setupTask
       xsi:type="maven:MavenImportTask"
       projectNameTemplate="">
     <sourceLocator
         rootFolder="${workspace.location/devcon}"/>
-  </setupTask>
-  <setupTask
-      xsi:type="setup:VariableTask"
-      name="eclipse.target.platform"
-      defaultValue="Neon"
-      storageURI="scope://Workspace"
-      label="Eclipse Target Platform">
-    <choice
-        value="Oxygen"
-        label="Oxygen"/>
-    <choice
-        value="Neon"
-        label="Neon"/>
-    <choice
-        value="Mars"
-        label="Mars"/>
-  </setupTask>
-  <setupTask
-      xsi:type="setup.targlets:TargletTask">
-    <targlet
-        name="${scope.project.label}"
-        activeRepositoryList="${eclipse.target.platform}">
-      <requirement
-          name="org.eclipse.sdk.feature.group"/>
-      <requirement
-          name="*"/>
-      <sourceLocator
-          rootFolder="${workspace.location/devonfw-locale}"
-          locateNestedProjects="true"/>
-      <repositoryList
-          name="Oxygen">
-        <repository
-            url="http://download.eclipse.org/releases/oxygen"/>
-      </repositoryList>
-      <repositoryList
-          name="Neon">
-        <repository
-            url="http://download.eclipse.org/releases/neon"/>
-      </repositoryList>
-      <repositoryList
-          name="Mars">
-        <repository
-            url="http://download.eclipse.org/releases/mars"/>
-      </repositoryList>
-    </targlet>
   </setupTask>
   <stream name="develop"
       label="Develop"/>


### PR DESCRIPTION
I updated the Oomph Setup for the devcon project. The Eclipse Target Platform is removed and all user accessible variables are properly named