### PR TITLE
#Pending_issue_number Template version is read from the DevonFolder/conf/version.conf …

### DIFF
--- a/src/main/java/com/devonfw/devcon/common/utils/Constants.java
+++ b/src/main/java/com/devonfw/devcon/common/utils/Constants.java
@@ -44,6 +44,16 @@ public final class Constants {
   public static final String GLOBAL_PARAMS_FILE = "globalParameters.json";
 
   /**
+   * The name of the version parameters file
+   */
+  public static final String VERSION_PARAMS_FILE = "version.json";
+
+  /**
+   * The full path of the version parameters file
+   */
+  public static final String VERSION_PARAMS_FILE_FULL_PATH = "conf" + File.separator + VERSION_PARAMS_FILE;
+
+  /**
    * Constant defined for .git directory
    */
   public static final String DOT_GIT = "\\.git";

--- a/src/main/java/com/devonfw/devcon/common/utils/Utils.java
+++ b/src/main/java/com/devonfw/devcon/common/utils/Utils.java
@@ -404,6 +404,19 @@ public class Utils {
     else
       return path.endsWith(File.separator) ? path : path + File.separator;
   }
+  
+  /**
+   * Remove the ending dot (if exists) from the passed path
+   *
+   * @return the passed path without ending dot
+   */
+  public static String removeEndingDot(String path) {
+
+    if (path == null)
+      return path;
+    else
+      return path.endsWith(".") ? path.substring(0, path.length() - 1) : path;
+  }
 
   /**
    * Method to obtain the value of any JSON property file
@@ -433,4 +446,21 @@ public class Utils {
     return Optional.absent();
   }
 
+  /**
+   * Gets the template version from the passed config file path
+   *
+   * @param configPath Path where the config path is located on disk
+   * @return The template version or empty string if not found
+   */
+  public static String getTemplateVersion(String configPath) {
+
+    String oaspTemplateVersion = "";    
+    Optional<String> oaspTemplateVersionOp = Utils.getJSONConfigProperty(configPath, Constants.OASP_TEMPLATE_VERSION);    
+    if (oaspTemplateVersionOp.isPresent()) {
+      oaspTemplateVersion = oaspTemplateVersionOp.get();
+    }
+    return oaspTemplateVersion;
+  }
+
+  
 }

--- a/src/main/java/com/devonfw/devcon/common/utils/Utils.java
+++ b/src/main/java/com/devonfw/devcon/common/utils/Utils.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2015-2018 Capgemini SE.
- * 
+ *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,6 +18,7 @@ package com.devonfw.devcon.common.utils;
 import java.awt.Desktop;
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -31,6 +32,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,7 +44,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.json.JSONObject;
 
 import com.devonfw.devcon.Devcon;
 import com.devonfw.devcon.common.api.Command;
@@ -240,8 +244,8 @@ public class Utils {
     try {
       File appFolder = pathToApp.toFile();
       if (appFolder.exists()) {
-        String content =
-            "{\"version\": \"" + Devcon.DEVON_DEFAULT_VERSION + "\",\n\"type\":\"" + type.toString() + "\"}";
+        String content = "{\"version\": \"" + Devcon.DEVON_DEFAULT_VERSION + "\",\n\"type\":\"" + type.toString()
+            + "\"}";
         File settingsfile = pathToApp.resolve("devon.json").toFile();
         FileUtils.writeStringToFile(settingsfile, content, "UTF-8");
       }
@@ -387,4 +391,46 @@ public class Utils {
     }
     ShowCommandHandler.start.setDisable(false);
   }
+
+  /**
+   * Checks if the passed path ends with slash. If not, it's added
+   *
+   * @return the passed path with trailing slash
+   */
+  public static String addTrailingSlash(String path) {
+
+    if (path == null)
+      return path;
+    else
+      return path.endsWith(File.separator) ? path : path + File.separator;
+  }
+
+  /**
+   * Method to obtain the value of any JSON property file
+   *
+   * @param filePath Properties file path
+   * @param property name of the property
+   * @return the value of the passed property
+   */
+  public static Optional<String> getJSONConfigProperty(String filePath, String property) {
+
+    try {
+
+      File f = new File(filePath);
+      if (f.exists()) {
+        try (InputStream is = new FileInputStream(f)) {
+          String jsonTxt = IOUtils.toString(is, StandardCharsets.UTF_8);
+          JSONObject json = new JSONObject(jsonTxt);
+          String propertyValue = (String) json.get(property);
+          return Optional.of(propertyValue);
+        } catch (IOException ioex) {
+          ioex.printStackTrace();
+        }
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    return Optional.absent();
+  }
+
 }

--- a/src/main/java/com/devonfw/devcon/common/utils/Utils.java
+++ b/src/main/java/com/devonfw/devcon/common/utils/Utils.java
@@ -404,7 +404,7 @@ public class Utils {
     else
       return path.endsWith(File.separator) ? path : path + File.separator;
   }
-  
+
   /**
    * Remove the ending dot (if exists) from the passed path
    *
@@ -447,20 +447,25 @@ public class Utils {
   }
 
   /**
-   * Gets the template version from the passed config file path
+   * Gets the template version. Firstly, tries to get it from the passed config file path. If not found, tries to get it
+   * from Internet (the devonfw.github.io repository). Else, raise error to end-users.
    *
    * @param configPath Path where the config path is located on disk
    * @return The template version or empty string if not found
    */
   public static String getTemplateVersion(String configPath) {
 
-    String oaspTemplateVersion = "";    
-    Optional<String> oaspTemplateVersionOp = Utils.getJSONConfigProperty(configPath, Constants.OASP_TEMPLATE_VERSION);    
+    String oaspTemplateVersion = "";
+    Optional<String> oaspTemplateVersionOp = Utils.getJSONConfigProperty(configPath, Constants.OASP_TEMPLATE_VERSION);
     if (oaspTemplateVersionOp.isPresent()) {
       oaspTemplateVersion = oaspTemplateVersionOp.get();
+    } else {
+      oaspTemplateVersionOp = Downloader.getDevconConfigProperty(Constants.OASP_TEMPLATE_VERSION);
+      if (oaspTemplateVersionOp.isPresent()) {
+        oaspTemplateVersion = oaspTemplateVersionOp.get();
+      }
     }
     return oaspTemplateVersion;
   }
 
-  
 }

--- a/src/main/java/com/devonfw/devcon/modules/oasp4j/Oasp4j.java
+++ b/src/main/java/com/devonfw/devcon/modules/oasp4j/Oasp4j.java
@@ -93,9 +93,11 @@ public class Oasp4j extends AbstractCommandModule {
 
     serverpath = serverpath.isEmpty() ? getContextPathInfo().getCurrentWorkingDirectory().toString() : serverpath;
 
-    String oaspTemplateVersion = Utils.getTemplateVersion(Utils.addTrailingSlash(Utils.removeEndingDot(serverpath)) + Constants.VERSION_PARAMS_FILE_FULL_PATH);
+    String oaspTemplateVersion = Utils.getTemplateVersion(
+        Utils.addTrailingSlash(Utils.removeEndingDot(serverpath)) + Constants.VERSION_PARAMS_FILE_FULL_PATH);
     if (oaspTemplateVersion.isEmpty())
-      this.output.showError("Oasp template version not found in config file.");
+      this.output.showError(
+          "Oasp template version not found neither in config file '{devonfwPath}/conf/version.json' nor Internet. Please, go online or setup the config file correctly.");
 
     this.output.showMessage("Using the oasp template version: " + oaspTemplateVersion);
 

--- a/src/main/java/com/devonfw/devcon/modules/oasp4j/Oasp4j.java
+++ b/src/main/java/com/devonfw/devcon/modules/oasp4j/Oasp4j.java
@@ -53,7 +53,6 @@ import com.devonfw.devcon.common.api.data.ProjectInfo;
 import com.devonfw.devcon.common.api.data.ProjectType;
 import com.devonfw.devcon.common.impl.AbstractCommandModule;
 import com.devonfw.devcon.common.utils.Constants;
-import com.devonfw.devcon.common.utils.Downloader;
 import com.devonfw.devcon.common.utils.Utils;
 import com.google.common.base.Optional;
 
@@ -94,7 +93,7 @@ public class Oasp4j extends AbstractCommandModule {
 
     serverpath = serverpath.isEmpty() ? getContextPathInfo().getCurrentWorkingDirectory().toString() : serverpath;
 
-    String oaspTemplateVersion = getTemplateVersion(serverpath);
+    String oaspTemplateVersion = Utils.getTemplateVersion(Utils.addTrailingSlash(Utils.removeEndingDot(serverpath)) + Constants.VERSION_PARAMS_FILE_FULL_PATH);
     if (oaspTemplateVersion.isEmpty())
       this.output.showError("Oasp template version not found in config file.");
 
@@ -570,27 +569,5 @@ public class Oasp4j extends AbstractCommandModule {
     return dependency;
   }
 
-  /**
-   * Gets the template version from the version.json file. Firstly, it's searching for it on devonfw.github.io
-   * repository. If not found, it's searching for it in the DevonFolder/conf/ folder.
-   *
-   * @param serverPath Path where DEVON server is located on disk
-   * @return The template version or empty string if not found
-   */
-  private String getTemplateVersion(String serverPath) {
-
-    String oaspTemplateVersion = "";
-    Optional<String> oaspTemplateVersion_op = Downloader.getDevconConfigProperty(Constants.OASP_TEMPLATE_VERSION); // Optional.of("2.3.0");
-    if (oaspTemplateVersion_op.isPresent()) {
-      oaspTemplateVersion = oaspTemplateVersion_op.get();
-    } else {
-      String configPath = Utils.addTrailingSlash(serverPath) + Constants.VERSION_PARAMS_FILE_FULL_PATH;
-      oaspTemplateVersion_op = Utils.getJSONConfigProperty(configPath, Constants.OASP_TEMPLATE_VERSION);
-      if (oaspTemplateVersion_op.isPresent()) {
-        oaspTemplateVersion = oaspTemplateVersion_op.get();
-      }
-    }
-    return oaspTemplateVersion;
-  }
-
+ 
 }

--- a/src/test/java/com/devonfw/devcon/module/UtilsTest.java
+++ b/src/test/java/com/devonfw/devcon/module/UtilsTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright 2015-2018 Capgemini SE.
+ * 
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************/
+package com.devonfw.devcon.module;
+
+import static org.junit.Assert.assertTrue;
+
+import java.net.URISyntaxException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.devonfw.devcon.common.utils.Constants;
+import com.devonfw.devcon.common.utils.Utils;
+
+
+/**
+ * Tests the Utils module
+ *
+ * @author dsanchez
+ */
+public class UtilsTest {
+	
+  	
+  @SuppressWarnings("javadoc")
+  @Before
+  public void setup() {
+
+  
+  }
+
+  @Test
+  public void testGetTemplateVersion() throws URISyntaxException {
+
+  	String configPath = this.getClass().getResource("").getPath().replace("com/devonfw/devcon/module/", "") + Constants.VERSION_PARAMS_FILE_FULL_PATH;	  
+  	String templateVersion = Utils.getTemplateVersion(configPath);
+    assertTrue(templateVersion.equals("2.6.0"));
+  }
+  
+  @Test
+  public void testRemoveEndingDot() throws URISyntaxException {
+
+  	String path = this.getClass().getResource("").getPath() + ".";  	
+  	path = Utils.removeEndingDot(path);  	
+    assertTrue(path.equals(this.getClass().getResource("").getPath()));
+    path = Utils.removeEndingDot(path);    
+    assertTrue(path.equals(this.getClass().getResource("").getPath()));
+  }
+
+
+  @After
+  public void end() {
+
+  }
+
+}

--- a/src/test/resources/conf/version.json
+++ b/src/test/resources/conf/version.json
@@ -1,0 +1,10 @@
+{
+  "version":"1.5.0",
+  "url":"http://devonfw.github.io/download/devcon/devcon.jar",
+  "devondist_file_id": "frs65334",
+  "devondist_file_linux_id": "frs65335",
+  "oaspide_file_id": "frs54315",
+  "oasp4js_ang1_id": "frs51721",
+  "oasp4js_ang2_id": "frs51961",
+  "oasp_template_version": "2.6.0"
+}


### PR DESCRIPTION
**Issue number**: Pending to be created
**Description**: If network is not available the template version is set with the value of the fixed constant OASP_TEMPLATE_LAST_STABLE_VERSION. This fixed value might be different from the one in GitHub.

The new changes read the template version from the local file "DevonServerPath/conf/version.json". That file must have a property called "oasp_template_version". That file must be included in future Devon releases.

Regarding the changes:
1 - Added 2 new constants in "Constants.java"
2 - Added 2 new methods in "Utils.java"
3 - Added a new method called "getTemplateVersion" in "oasp4j.java" to encapsulate all the template version logic. If network is available, it reads the  "version.json" from GitHub. Otherwise, it's read from local file "DevonServerPath/conf/version.json". If not found, empty string is returned.

**Note**: Unless there is a big constraint to keep reading "version.json" from GitHub, probably we should stop using it and always read the local  "version.json" file. It's an easy change.
