### PR TITLE
Feature 135 code migration

### DIFF
--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/Migrations.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/Migrations.java
@@ -37,6 +37,9 @@ public class Migrations {
         .to(VersionIdentifier.ofDevon4j("3.0.0")) //
         .pom().replaceProperty("oasp4j.version", "3.0.0", "devon4j.version") //
         .replaceRegex("\\s*\\$\\{oasp4j\\.version\\}\\s*", "\\$\\{devon4j.version\\}") //
+        .replaceProperty("oasp.test.excluded.groups", null, "devonfw.test.excluded.groups") //
+        .replaceRegex("\\s*\\$\\{oasp\\.test\\.excluded\\.groups\\}\\s*", "\\$\\{devonfw.test.excluded.groups\\}") //
+        .replaceRegex("io\\.oasp\\.module\\.test\\.", "com.devonfw.module.test.") //
         .replaceDependency(new VersionIdentifier(VersionIdentifier.GROUP_ID_OASP4J, "oasp4j-bom", null),
             new VersionIdentifier(VersionIdentifier.GROUP_ID_DEVON4J_BOMS, "devon4j-bom", null))
         .replaceDependency(new VersionIdentifier(VersionIdentifier.GROUP_ID_OASP4J + "*", "oasp4j*", null),

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/Migrations.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/Migrations.java
@@ -35,8 +35,8 @@ public class Migrations {
         .applicationProperties().replace("flyway.", "spring.flyway.").and().next() //
 
         .to(VersionIdentifier.ofDevon4j("3.0.0")) //
-        .pom().replaceProperty("oasp4j.version", "3.0.0-SNAPSHOT", "devon4j.version") //
-        .replaceString("${oasp4j.version}", "${devon4j.version}") //
+        .pom().replaceProperty("oasp4j.version", "3.0.0", "devon4j.version") //
+        .replaceRegex("\\s*\\$\\{oasp4j\\.version\\}\\s*", "\\$\\{devon4j.version\\}") //
         .replaceDependency(new VersionIdentifier(VersionIdentifier.GROUP_ID_OASP4J, "oasp4j-bom", null),
             new VersionIdentifier(VersionIdentifier.GROUP_ID_DEVON4J_BOMS, "devon4j-bom", null))
         .replaceDependency(new VersionIdentifier(VersionIdentifier.GROUP_ID_OASP4J + "*", "oasp4j*", null),

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/Migrations.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/Migrations.java
@@ -23,21 +23,35 @@ public class Migrations {
         .pom().replaceProperty("oasp4j.version", "2.6.1").and().next() //
 
         .to(VersionIdentifier.ofOasp4j("3.0.0")) //
-        .pom().replaceProperty("oasp4j.version", "3.0.0").and() //
+        .pom().replaceProperty("oasp4j.version", "3.0.0") //
+        .replaceProperty("spring.boot.version", "2.0.4.RELEASE") //
+        .replaceProperty("flyway.version", "5.0.7") //
+        .replaceDependency(new VersionIdentifier("org.hibernate", "hibernate-validator", null),
+            new VersionIdentifier("org.hibernate.validator", "hibernate-validator", null))
+        .and() //
         .java().replace("org.hibernate.Query", "org.hibernate.query.Query")
         .replace("com.mysema.query.alias.Alias", "com.querydsl.core.alias.Alias")
         .replace("com.mysema.query.jpa.impl.JPAQuery", "com.querydsl.jpa.impl.JPAQuery")
         .replace("com.mysema.query.types.path.EntityPathBase", "com.querydsl.core.types.dsl.EntityPathBase")
+        .replace("org.springframework.boot.web.support.SpringBootServletInitializer",
+            "org.springframework.boot.web.servlet.support.SpringBootServletInitializer")
+        .replace("org.springframework.boot.context.embedded.LocalServerPort",
+            "org.springframework.boot.web.server.LocalServerPort")
+        .replace("org.springframework.boot.actuate.autoconfigure.EndpointAutoConfiguration",
+            "org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration")
+        .replace("org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration",
+            "org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration")
+        .replace("org.springframework.boot.autoconfigure.security.SecurityFilterAutoConfiguration",
+            "org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration")
         .replace("query.clone().count()", "query.clone().fetchCount()").replace("query.count()", "query.fetchCount()")
         .replace("query.list(expr)", "query.select(expr).fetch()").replace("query.list()", "query.fetch()")
         .replace("query.firstResult(", "query.fetchFirst(").replace("query.uniqueResult(", "query.fetchUnique(")
         .replace("query.listResults(", "query.fetchResults(").add(new QueryDslJpaQueryLineMigration()).and() //
-        .applicationProperties().replace("flyway.", "spring.flyway.").and().next() //
+        .applicationProperties().replace("flyway.", "spring.flyway.") //
+        .replace("server.context-path", "server.servlet.context-path").and().next() //
 
         .to(VersionIdentifier.ofDevon4j("3.0.0")) //
         .pom().replaceProperty("oasp4j.version", "3.0.0", "devon4j.version") //
-        .replaceProperty("spring.boot.version", "2.0.4.RELEASE") //
-        .replaceProperty("flyway.version", "5.0.7") //
         .replaceRegex("\\s*\\$\\{oasp4j\\.version\\}\\s*", "\\$\\{devon4j.version\\}") //
         .replaceProperty("oasp.test.excluded.groups", null, "devonfw.test.excluded.groups") //
         .replaceRegex("\\s*\\$\\{oasp\\.test\\.excluded\\.groups\\}\\s*", "\\$\\{devonfw.test.excluded.groups\\}") //

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/Migrations.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/Migrations.java
@@ -36,6 +36,8 @@ public class Migrations {
 
         .to(VersionIdentifier.ofDevon4j("3.0.0")) //
         .pom().replaceProperty("oasp4j.version", "3.0.0", "devon4j.version") //
+        .replaceProperty("spring.boot.version", "2.0.4.RELEASE") //
+        .replaceProperty("flyway.version", "5.0.7") //
         .replaceRegex("\\s*\\$\\{oasp4j\\.version\\}\\s*", "\\$\\{devon4j.version\\}") //
         .replaceProperty("oasp.test.excluded.groups", null, "devonfw.test.excluded.groups") //
         .replaceRegex("\\s*\\$\\{oasp\\.test\\.excluded\\.groups\\}\\s*", "\\$\\{devonfw.test.excluded.groups\\}") //

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/Migrations.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/Migrations.java
@@ -101,6 +101,8 @@ public class Migrations {
             "AbstractEto extends com.devonfw.module.basic.common.api.to.AbstractEto")
         .replace("EntityTo<Long>", "AbstractEto").replace("MutableGenericEntity<", "GenericEntity<")
         .replace("net.sf.mmm.util.transferobject.api.EntityTo", "com.devonfw.module.basic.common.api.to.AbstractEto")
+        .replace("/io/oasp/module/security/access-control-schema.xsd",
+            "/com/devonfw/module/security/access-control-schema.xsd") //
         .replace(".OaspPackage", ".Devon4jPackage").replace("OaspPackage ", "Devon4jPackage ")
         .replace("OaspPackage.", "Devon4jPackage.")
         .replace("import com.devonfw.module.basic.common.api.to.AbstractEto;", "",

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/builder/PomXmlMigrationBuilder.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/builder/PomXmlMigrationBuilder.java
@@ -1,10 +1,13 @@
 package com.devonfw.devcon.modules.devon4j.migrate.builder;
 
+import java.util.regex.Pattern;
+
 import com.devonfw.devcon.modules.devon4j.migrate.file.XmlFileMigration;
 import com.devonfw.devcon.modules.devon4j.migrate.version.VersionIdentifier;
 import com.devonfw.devcon.modules.devon4j.migrate.xml.MavenDependencyAdder;
 import com.devonfw.devcon.modules.devon4j.migrate.xml.MavenDependencyReplacement;
 import com.devonfw.devcon.modules.devon4j.migrate.xml.MavenPropertyReplacement;
+import com.devonfw.devcon.modules.devon4j.migrate.xml.XmlRegexReplacement;
 import com.devonfw.devcon.modules.devon4j.migrate.xml.XmlStringReplacement;
 
 /**
@@ -74,6 +77,27 @@ public class PomXmlMigrationBuilder extends XmlMigrationBuilder {
   public PomXmlMigrationBuilder replaceString(String search, String replacement) {
 
     this.migration.getMigrations().add(new XmlStringReplacement(search, replacement));
+    return this;
+  }
+
+  /**
+   * @param pattern the plain {@link Pattern} to replace in POM.
+   * @param replacement the replacement {@link String}.
+   * @return {@code this}.
+   */
+  public PomXmlMigrationBuilder replaceRegex(String pattern, String replacement) {
+
+    return replaceRegex(Pattern.compile(pattern), replacement);
+  }
+
+  /**
+   * @param pattern the plain {@link Pattern} to replace in POM.
+   * @param replacement the replacement {@link String}.
+   * @return {@code this}.
+   */
+  public PomXmlMigrationBuilder replaceRegex(Pattern pattern, String replacement) {
+
+    this.migration.getMigrations().add(new XmlRegexReplacement(pattern, replacement));
     return this;
   }
 

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/xml/XmlRegexReplacement.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/xml/XmlRegexReplacement.java
@@ -1,6 +1,5 @@
 package com.devonfw.devcon.modules.devon4j.migrate.xml;
 
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.w3c.dom.Document;
@@ -53,9 +52,10 @@ public class XmlRegexReplacement extends AbstractXmlMigration {
         }
       } else if (nodeType == Node.TEXT_NODE) {
         Text text = (Text) node;
-        Matcher matcher = this.pattern.matcher(text.getData());
-        if (matcher.matches()) {
-          text.setData(matcher.replaceAll(this.replacement));
+        String data = text.getData();
+        String newData = data.replaceAll(this.pattern.pattern(), this.replacement);
+        if (!data.equals(newData)) {
+          text.setData(newData);
           updated = true;
         }
       }

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/xml/XmlRegexReplacement.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/xml/XmlRegexReplacement.java
@@ -1,0 +1,66 @@
+package com.devonfw.devcon.modules.devon4j.migrate.xml;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.Text;
+
+/**
+ * Implementation of {@link AbstractXmlMigration} for a simple {@link String} replacement in any
+ * {@link Element#getTextContent() text}. Currently no attributes are supported as focus is so far on maven that does
+ * not make use of attributes.
+ */
+public class XmlRegexReplacement extends AbstractXmlMigration {
+
+  private Pattern pattern;
+
+  private String replacement;
+
+  /**
+   * The constructor.
+   *
+   * @param pattern the {@link Pattern} to search for.
+   * @param replacement the replacement for the given {@code search} {@link String}.
+   */
+  public XmlRegexReplacement(Pattern pattern, String replacement) {
+
+    super();
+    this.pattern = pattern;
+    this.replacement = replacement;
+  }
+
+  @Override
+  public boolean migrateXml(Document xml) throws Exception {
+
+    return migrateXmlElement(xml.getDocumentElement());
+  }
+
+  private boolean migrateXmlElement(Element element) {
+
+    boolean updated = false;
+    NodeList childNodes = element.getChildNodes();
+    for (int i = 0; i < childNodes.getLength(); i++) {
+      Node node = childNodes.item(i);
+      short nodeType = node.getNodeType();
+      if (nodeType == Node.ELEMENT_NODE) {
+        boolean childUpdated = migrateXmlElement((Element) node);
+        if (childUpdated) {
+          updated = true;
+        }
+      } else if (nodeType == Node.TEXT_NODE) {
+        Text text = (Text) node;
+        Matcher matcher = this.pattern.matcher(text.getData());
+        if (matcher.matches()) {
+          text.setData(matcher.replaceAll(this.replacement));
+          updated = true;
+        }
+      }
+    }
+    return updated;
+  }
+
+}


### PR DESCRIPTION
Further improvements for #135 
It fixes the issues observed and reported by @vapadwal 

Still a newly migrated app will most probably end up with errors like:
```
There is no PasswordEncoder mapped for the id "null"
```
Unfortunately spring-boot cares too less for backward compatibility. I covered all package refactorings, etc. but to fix this last aspect, I would to deep-dive into the code details. This would require to find the proper sub-class of `WebSecurityConfigurerAdapter` that is responsible for the security config and insert the password encoder there into the code. I really dislike the way spring-boot removed defaults and left the users alone with the problem.
However, the only chance I see here is that we write a proper migration guide documentation for such manual steps and output the URL to this guide in devcon as we would need AI to automate such code migration feature.
This is the fix we did in oasp4j during spring-boot upgrade including the required password encoder changes:
https://github.com/oasp/oasp4j/commit/fa541f45e1a0d01c02cce0f32083f19b46497310