### PR TITLE
Passes all tests on Linux (RegistryTest deactivated on Linux)

### DIFF
--- a/src/test/java/com/devonfw/devcon/basic/RegistryTest.java
+++ b/src/test/java/com/devonfw/devcon/basic/RegistryTest.java
@@ -18,6 +18,7 @@ package com.devonfw.devcon.basic;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.Test;
 
 import com.devonfw.devcon.common.impl.utils.WindowsReqistry;
@@ -32,6 +33,10 @@ public class RegistryTest {
 
   @Test
   public void testRegistry() {
+
+    if (!SystemUtils.IS_OS_WINDOWS){
+      return;
+    }
 
     // given
     // set reg value


### PR DESCRIPTION
On Linux the RegistryTest class fails when executing on Linux because of non-windows specific functionality (WIndows Registry). This patch disables (escapes from) the test when running on a non-Windows platform.